### PR TITLE
Creación de endpoints necesarios para el flujo deployado

### DIFF
--- a/back/src/Auth/auth.service.ts
+++ b/back/src/Auth/auth.service.ts
@@ -104,7 +104,7 @@ export class AuthService {
       id: string;
       name: string;
       email: string;
-      imgUrl: string;
+      // imgUrl: string;
       role: UserRole;
       hasServiceProfile: boolean;
     };
@@ -126,7 +126,7 @@ export class AuthService {
         id: user.id,
         name: user.name,
         email: user.email,
-        imgUrl: user.imgUrl,
+        // imgUrl: user.imgUrl,
         role: user.role,
         hasServiceProfile,
       },

--- a/back/src/Auth/strategies/google.strategy.ts
+++ b/back/src/Auth/strategies/google.strategy.ts
@@ -29,9 +29,9 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
       phone: 0, // Valor temporal, el usuario deberá actualizarlo
       address: 'Dirección no especificada', // Valor temporal
       password: '', // No necesaria para OAuth
-      imgUrl:
-        photos?.[0]?.value ||
-        'https://www.shutterstock.com/image-vector/default-avatar-profile-social-media-600nw-1920331226.jpg',
+      // imgUrl:
+      //   photos?.[0]?.value ||
+      //   'https://www.shutterstock.com/image-vector/default-avatar-profile-social-media-600nw-1920331226.jpg',
       role: UserRole.CUSTOMER, // Rol por defecto
     };
 
@@ -49,12 +49,12 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
         user = await this.usersRepository.updateUserRepository(user.id, user);
       } else {
         // Actualizar imagen si es necesario
-        if (!user.imgUrl && userData.imgUrl) {
-          user.imgUrl = userData.imgUrl;
-          user = await this.usersRepository.updateUserRepository(user.id, {
-            imgUrl: user.imgUrl,
-          });
-        }
+        // if (!user.imgUrl && userData.imgUrl) {
+        //   user.imgUrl = userData.imgUrl;
+        //   user = await this.usersRepository.updateUserRepository(user.id, {
+        //     imgUrl: user.imgUrl,
+        //   });
+        // }
       }
 
       done(null, user);

--- a/back/src/DTO/serviceProfileDtos/createServiceProfile.dto.ts
+++ b/back/src/DTO/serviceProfileDtos/createServiceProfile.dto.ts
@@ -41,6 +41,13 @@ export class CreateServiceProfileDto {
   phone: string;
 
   @ApiProperty({
+    example:
+      'https://www.shutterstock.com/image-vector/default-avatar-profile-social-media-600nw-1920331226.jpg',
+    description: 'Foto de perfil',
+  })
+  profilePicture: string;
+
+  @ApiProperty({
     example: 'Electricidad',
     description: 'Categoría del servicio',
   })

--- a/back/src/DTO/userDtos/userResponse.dto.ts
+++ b/back/src/DTO/userDtos/userResponse.dto.ts
@@ -15,8 +15,6 @@ export class UsersResponseDto {
 
   role: UserRole;
 
-  imgUrl: string;
-
   createdAt: Date;
 
   updatedAt: Date;

--- a/back/src/appointments/appointments.controller.ts
+++ b/back/src/appointments/appointments.controller.ts
@@ -53,8 +53,8 @@ export class AppointmentsController {
   @Get('myAppointments')
   @ApiBearerAuth()
   @UseGuards(AuthGuard)
-  getMyappointmentsController(@GetUser() user: IJwtPayload){
-    return this.appointmentsService.getMyAppointments(user.id)
+  getMyappointmentsController(@GetUser() user: IJwtPayload) {
+    return this.appointmentsService.getMyAppointments(user.id);
   }
 
   // OBTENER UNA CITA BY ID

--- a/back/src/appointments/appointments.module.ts
+++ b/back/src/appointments/appointments.module.ts
@@ -13,7 +13,7 @@ import { MailModule } from 'src/mail/mail.module';
     TypeOrmModule.forFeature([Appointment]),
     UsersModule,
     ServiceProfileModule,
-    MailModule
+    MailModule,
   ],
   controllers: [AppointmentsController],
   providers: [AppointmentsService, AppointmentsRepository],

--- a/back/src/appointments/appointments.repository.ts
+++ b/back/src/appointments/appointments.repository.ts
@@ -28,17 +28,17 @@ export class AppointmentsRepository {
   // OBTENER TODAS LAS CITAS
   async getAllAppointmentsRepository(): Promise<Appointment[]> {
     return await this.appointmentsRepository.find({
-      relations: ['users']
+      relations: ['users'],
     });
   }
 
   //OBTENER TODOS MIS APPTS
-  async getMyAppointmentsRepository(userId: string): Promise<Appointment[]>{
+  async getMyAppointmentsRepository(userId: string): Promise<Appointment[]> {
     return this.appointmentsRepository.find({
-      where: {users: {id: userId}},
+      where: { users: { id: userId } },
       relations: ['users'],
-      order: {date: 'ASC'}
-    })
+      order: { date: 'ASC' },
+    });
   }
 
   // OBTENER UNA CITA BY ID

--- a/back/src/appointments/appointments.service.ts
+++ b/back/src/appointments/appointments.service.ts
@@ -24,7 +24,7 @@ export class AppointmentsService {
     private readonly appointmentsRepository: AppointmentsRepository,
     private readonly usersRepository: UsersRepository,
     private readonly serviceProfileRepository: ServiceProfileRepository,
-    private readonly mailService: MailService
+    private readonly mailService: MailService,
   ) {}
 
   // CREAR UNA CITA
@@ -45,7 +45,6 @@ export class AppointmentsService {
         `No se puede crear una cita con un perfil de servicio no activado`,
       );
 
-
     const appointmentToCreate: AppointmentToSaveDto = {
       date: new Date(createAppointment.date),
       additionalNotes: createAppointment.additionalNotes,
@@ -63,35 +62,37 @@ export class AppointmentsService {
         appointmentToCreate,
       );
 
-     try {
-    // Enviar correo al cliente (solo si tiene email)
-    if (user.email) {
-      await this.mailService.sendAppointmentConfirmation(
-        user.email,
-        user.name,
-        provider.userName,
-        provider.serviceTitle,
-        appointmentToCreate.date,
-        createAppointment.additionalNotes,
-      );
-    }
+    try {
+      // Enviar correo al cliente (solo si tiene email)
+      if (user.email) {
+        await this.mailService.sendAppointmentConfirmation(
+          user.email,
+          user.name,
+          provider.userName,
+          provider.serviceTitle,
+          appointmentToCreate.date,
+          createAppointment.additionalNotes,
+        );
+      }
 
-    // Enviar correo al proveedor (solo si tiene email)
-    if (provider.user?.email) {
-      await this.mailService.sendAppointmentNotificationToProvider(
-        provider.user.email, 
-        provider.userName,
-        user.name,
-        user.phone.toString(),
-        provider.serviceTitle,
-        appointmentToCreate.date,
-        createAppointment.additionalNotes,
+      // Enviar correo al proveedor (solo si tiene email)
+      if (provider.user?.email) {
+        await this.mailService.sendAppointmentNotificationToProvider(
+          provider.user.email,
+          provider.userName,
+          user.name,
+          user.phone.toString(),
+          provider.serviceTitle,
+          appointmentToCreate.date,
+          createAppointment.additionalNotes,
+        );
+      }
+    } catch (error) {
+      console.error('Error al enviar correos:', error);
+      throw new InternalServerErrorException(
+        'Error al enviar notificaciones por correo',
       );
     }
-  } catch (error) {
-    console.error('Error al enviar correos:', error);
-    throw new InternalServerErrorException('Error al enviar notificaciones por correo');
-  }
 
     return await this.appointmentsRepository.saveAppointmentRepository(
       savedAppointment,
@@ -104,8 +105,8 @@ export class AppointmentsService {
   }
 
   //OBTENER TODOS MIS APPOINTMENTS
-  async getMyAppointments(userId: string): Promise<Appointment[]>{
-    return this.appointmentsRepository.getMyAppointmentsRepository(userId)
+  async getMyAppointments(userId: string): Promise<Appointment[]> {
+    return this.appointmentsRepository.getMyAppointmentsRepository(userId);
   }
 
   // OBTENER UNA CITA BY ID

--- a/back/src/entities/media.entity.ts
+++ b/back/src/entities/media.entity.ts
@@ -6,6 +6,7 @@ import {
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { ServiceProfile } from './serviceProfile.entity';
+import { MediaType } from 'src/enums/mediaType.enum';
 
 @Entity({ name: 'media' })
 export class Media {
@@ -14,6 +15,13 @@ export class Media {
 
   @Column({ type: 'varchar', nullable: false })
   imgUrl: string;
+
+  @Column({
+    type: 'enum',
+    enum: MediaType,
+    default: MediaType.GALLERY,
+  })
+  type: MediaType;
 
   @ManyToOne(() => ServiceProfile, (serviceProfile) => serviceProfile.images)
   @JoinColumn({ name: 'serviceProfile_id' })

--- a/back/src/entities/serviceProfile.entity.ts
+++ b/back/src/entities/serviceProfile.entity.ts
@@ -17,6 +17,8 @@ import { Review } from './reviews.entity';
 import { Subscriptions } from './subcriptions.entity';
 import { Order } from './orders.entity';
 import { ServiceProfileStatus } from 'src/enums/serviceProfileStatus.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsUrl } from 'class-validator';
 
 @Entity({
   name: 'service_profiles',
@@ -65,6 +67,17 @@ export class ServiceProfile {
     default: ServiceProfileStatus.PENDING,
   })
   status: ServiceProfileStatus;
+
+  @ApiProperty({
+    description: 'Imagen de perfil del usuario',
+    example: 'https://example.com/images/headphones.jpg',
+  })
+  @Column({
+    type: 'text',
+    nullable: false,
+  })
+  @IsUrl()
+  profilePicture: string;
 
   @CreateDateColumn({
     type: 'timestamp',

--- a/back/src/entities/user.entity.ts
+++ b/back/src/entities/user.entity.ts
@@ -116,19 +116,6 @@ export class User {
   role: UserRole;
 
   @ApiProperty({
-    description: 'Imagen de perfil del usuario',
-    example: 'https://example.com/images/headphones.jpg',
-  })
-  @Column({
-    type: 'text',
-    default:
-      'https://www.shutterstock.com/image-vector/default-avatar-profile-social-media-600nw-1920331226.jpg',
-  })
-  @IsOptional()
-  @IsUrl()
-  imgUrl: string;
-
-  @ApiProperty({
     description: 'Fecha de creación del usuario',
   })
   @CreateDateColumn({

--- a/back/src/enums/mediaType.enum.ts
+++ b/back/src/enums/mediaType.enum.ts
@@ -1,0 +1,5 @@
+export enum MediaType {
+  GALLERY = 'gallery',
+  CERTIFICATE = 'certificate',
+  ID_DOCUMENT = 'id_document',
+}

--- a/back/src/mail/mail.service.ts
+++ b/back/src/mail/mail.service.ts
@@ -128,7 +128,6 @@ export class MailService {
     return template(context);
   }
 
-
   //envio de correo al usuario al realizar un appointment
   async sendAppointmentConfirmation(
     userEmail: string,
@@ -136,16 +135,16 @@ export class MailService {
     providerName: string,
     providerService: string,
     appointmentDate: Date,
-    additionalNotes?: string
+    additionalNotes?: string,
   ) {
     const templatePath = path.join(
       process.cwd(),
       'src',
       'mail',
       'templates',
-      'appointment-confirmation.hbs'
+      'appointment-confirmation.hbs',
     );
-  
+
     const template = handlebars.compile(fs.readFileSync(templatePath, 'utf8'));
     const html = template({
       userName,
@@ -157,11 +156,11 @@ export class MailService {
         month: 'long',
         day: 'numeric',
         hour: '2-digit',
-        minute: '2-digit'
+        minute: '2-digit',
       }),
-      additionalNotes: additionalNotes || 'Ninguna'
+      additionalNotes: additionalNotes || 'Ninguna',
     });
-  
+
     await this.transporter.sendMail({
       from: `"TecniClick" <${process.env.MAIL_FROM}>`,
       to: userEmail,
@@ -169,7 +168,7 @@ export class MailService {
       html,
     });
   }
-  
+
   // CREACION DE APPT NOTIFICACION PROVEEDOR DE SERVICIO
   async sendAppointmentNotificationToProvider(
     providerEmail: string,
@@ -178,16 +177,16 @@ export class MailService {
     userPhone: string,
     serviceTitle: string,
     appointmentDate: Date,
-    additionalNotes?: string
+    additionalNotes?: string,
   ) {
     const templatePath = path.join(
       process.cwd(),
       'src',
       'mail',
       'templates',
-      'appointment-provider-notification.hbs'
+      'appointment-provider-notification.hbs',
     );
-  
+
     const template = handlebars.compile(fs.readFileSync(templatePath, 'utf8'));
     const html = template({
       providerName,
@@ -200,11 +199,11 @@ export class MailService {
         month: 'long',
         day: 'numeric',
         hour: '2-digit',
-        minute: '2-digit'
+        minute: '2-digit',
       }),
-      additionalNotes: additionalNotes || 'Ninguna'
+      additionalNotes: additionalNotes || 'Ninguna',
     });
-  
+
     await this.transporter.sendMail({
       from: `"TecniClick" <${process.env.MAIL_FROM}>`,
       to: providerEmail,
@@ -212,12 +211,9 @@ export class MailService {
       html,
     });
   }
-  
+
   //ENVIO DE CORREO AL DESACTIVACION DE CUENTA LOGICAMENTE
-  async sendAccountDeactivatedEmail(
-    email: string,
-    name: string,
-  ) {
+  async sendAccountDeactivatedEmail(email: string, name: string) {
     const html = this.compileTemplate('account-deactivated.hbs', {
       name,
       deactivationDate: new Date().toLocaleDateString('es-ES', {
@@ -226,7 +222,7 @@ export class MailService {
         day: 'numeric',
       }),
     });
-  
+
     await this.transporter.sendMail({
       from: `"TecniClick - Soporte" <${process.env.MAIL_FROM}>`,
       to: email,
@@ -242,16 +238,16 @@ export class MailService {
     serviceTitle: string,
     rating: number,
     comment: string,
-    createdAt: Date
+    createdAt: Date,
   ) {
     const templatePath = path.join(
       process.cwd(),
       'src',
       'mail',
       'templates',
-      'review-deleted.hbs'
+      'review-deleted.hbs',
     );
-  
+
     const template = handlebars.compile(fs.readFileSync(templatePath, 'utf8'));
     const html = template({
       userName,
@@ -263,15 +259,15 @@ export class MailService {
         month: 'long',
         day: 'numeric',
         hour: '2-digit',
-        minute: '2-digit'
-      })
+        minute: '2-digit',
+      }),
     });
-  
+
     await this.transporter.sendMail({
       from: `"TecniClick - Soporte" <${process.env.MAIL_FROM}>`,
       to: email,
       subject: 'Notificación: Tu reseña ha sido eliminada',
-      html
+      html,
     });
   }
 }

--- a/back/src/media/media.controller.ts
+++ b/back/src/media/media.controller.ts
@@ -12,16 +12,89 @@ import {
   ParseFilePipe,
   MaxFileSizeValidator,
   FileTypeValidator,
+  Query,
 } from '@nestjs/common';
 import { MediaService } from './media.service';
 import { ApiBearerAuth, ApiBody, ApiConsumes } from '@nestjs/swagger';
 import { AuthGuard } from 'src/Auth/guards/auth.guard';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { MediaType } from 'src/enums/mediaType.enum';
 
 @Controller('media')
 export class MediaController {
   constructor(private readonly mediaService: MediaService) {}
 
+  // OBTIENE TODOS LOS DOCUMENTOS EN MEDIA
+  @Get()
+  getAllMediaController() {
+    return this.mediaService.getAllMediaService();
+  }
+
+  // OBTIENE TODOS LOS DOCUMENTOS DE TIPO GALLERY EN MEDIA DE UN PERFIL
+  @Get('gallery/:profileId')
+  getGalleryByProfileController(@Param('profileId') profileId: string) {
+    return this.mediaService.getMediaByProfileAndTypeService(
+      profileId,
+      MediaType.GALLERY,
+    );
+  }
+
+  // OBTIENE TODOS LOS DOCUMENTOS DE TIPO CERTIFICATE EN MEDIA DE UN PERFIL
+  @Get('certificates/:profileId')
+  getCertificatesByProfileController(@Param('profileId') profileId: string) {
+    return this.mediaService.getMediaByProfileAndTypeService(
+      profileId,
+      MediaType.CERTIFICATE,
+    );
+  }
+
+  // OBTIENE TODOS LOS DOCUMENTOS DE TIPO ID_DOCUMENTS EN MEDIA DE UN PERFIL
+  @Get('id-documents/:profileId')
+  getIdDocumentsByProfileController(@Param('profileId') profileId: string) {
+    return this.mediaService.getMediaByProfileAndTypeService(
+      profileId,
+      MediaType.ID_DOCUMENT,
+    );
+  }
+
+  // CARGA DE FOTO DE PERFIL
+  @Post('profile-picture/:serviceProfileId')
+  @UseGuards(AuthGuard)
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiBearerAuth()
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  })
+  uploadProfilePicture(
+    @Param('serviceProfileId') id: string,
+    @UploadedFile(
+      new ParseFilePipe({
+        validators: [
+          new MaxFileSizeValidator({
+            maxSize: 5000000,
+            message: 'El archivo es demasiado pesado',
+          }),
+          new FileTypeValidator({
+            fileType: /^(image\/(jpeg|png|webp)|video\/(mp4|mov|avi))$/,
+          }),
+        ],
+      }),
+    )
+    file: Express.Multer.File,
+  ) {
+    return this.mediaService.uploadProfilePicture(id, file);
+  }
+
+  // CARGA DE FOTOS O DOCUMENTOS
   @Post('upload/:serviceProfileId')
   @UseGuards(AuthGuard)
   @UseInterceptors(FileInterceptor('file'))
@@ -40,6 +113,7 @@ export class MediaController {
   })
   uploadMediaController(
     @Param('serviceProfileId') id: string,
+    @Query('type') type: MediaType,
     @UploadedFile(
       new ParseFilePipe({
         validators: [
@@ -48,56 +122,57 @@ export class MediaController {
             message: 'El archivo es demasiado pesado',
           }),
           new FileTypeValidator({
-            fileType: /\.(jpg|jpeg|png|webp|mp4|mov|avi)$/i,
+            fileType:
+              /^(image\/(jpeg|png|webp)|application\/pdf|video\/(mp4|mov|avi))$/,
           }),
         ],
       }),
     )
     file: Express.Multer.File,
   ) {
-    return this.mediaService.uploadMediaService(id, file);
+    return this.mediaService.uploadMediaService(id, file, type);
   }
 
-  @ApiBearerAuth()
-  @Patch('foto/:userId')
-  @UseGuards(AuthGuard)
-  @UseInterceptors(FileInterceptor('file'))
-  @ApiConsumes('multipart/form-data')
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        file: {
-          type: 'string',
-          format: 'binary',
-        },
-      },
-    },
-  })
-  updateUserProfilePController(
-    @Param('userId') id: string,
-    @UploadedFile(
-      new ParseFilePipe({
-        validators: [
-          new MaxFileSizeValidator({
-            maxSize: 200000,
-            message: 'La imagen es demasiado pesada',
-          }),
-          new FileTypeValidator({
-            fileType: /(jpg|jpeg|png|webp)$/,
-          }),
-        ],
-      }),
-    )
-    file: Express.Multer.File,
-  ) {
-    return this.mediaService.updateUserProfileService(id, file);
-  }
+  // @ApiBearerAuth()
+  // @Patch('foto/:userId')
+  // @UseGuards(AuthGuard)
+  // @UseInterceptors(FileInterceptor('file'))
+  // @ApiConsumes('multipart/form-data')
+  // @ApiBody({
+  //   schema: {
+  //     type: 'object',
+  //     properties: {
+  //       file: {
+  //         type: 'string',
+  //         format: 'binary',
+  //       },
+  //     },
+  //   },
+  // })
+  // updateUserProfilePController(
+  //   @Param('userId') id: string,
+  //   @UploadedFile(
+  //     new ParseFilePipe({
+  //       validators: [
+  //         new MaxFileSizeValidator({
+  //           maxSize: 200000,
+  //           message: 'La imagen es demasiado pesada',
+  //         }),
+  //         new FileTypeValidator({
+  //           fileType: /(jpg|jpeg|png|webp)$/,
+  //         }),
+  //       ],
+  //     }),
+  //   )
+  //   file: Express.Multer.File,
+  // ) {
+  //   return this.mediaService.updateUserProfileService(id, file);
+  // }
 
-  @Delete('profileImage/:id')
-  @UseGuards(AuthGuard)
-  @ApiBearerAuth()
-  deleteUserProfilePictureController(@Param('id') id: string) {
-    return this.mediaService.deleteUserPofileService(id);
-  }
+  // @Delete('profileImage/:id')
+  // @UseGuards(AuthGuard)
+  // @ApiBearerAuth()
+  // deleteUserProfilePictureController(@Param('id') id: string) {
+  //   return this.mediaService.deleteUserPofileService(id);
+  // }
 }

--- a/back/src/media/media.repository.ts
+++ b/back/src/media/media.repository.ts
@@ -4,10 +4,14 @@ import { UploadApiResponse, v2 as Cloudinary } from 'cloudinary';
 import { Media } from 'src/entities/media.entity';
 import { Repository } from 'typeorm';
 import toStream = require('buffer-to-stream');
+import { MediaType } from 'src/enums/mediaType.enum';
 
 @Injectable()
 export class MediaRepository {
-  constructor() {}
+  constructor(
+    @InjectRepository(Media)
+    private readonly mediaRepository: Repository<Media>,
+  ) {}
   async uploadImage(file: Express.Multer.File): Promise<UploadApiResponse> {
     return new Promise((resolve, reject) => {
       const upload = Cloudinary.uploader.upload_stream(
@@ -21,6 +25,24 @@ export class MediaRepository {
         },
       );
       toStream(file.buffer).pipe(upload);
+    });
+  }
+
+  // // OBTIENE TODOS LOS DOCUMENTOS EN MEDIA
+  async getAllMediaRepository() {
+    return this.mediaRepository.find({
+      relations: ['serviceProfile'],
+    });
+  }
+
+  // OBTIENE TODOS LOS DOCUMENTOS EN MEDIA POR TIPO DE UN PERFIL
+  async getMediaByProfileAndTypeRepository(profileId: string, type: MediaType) {
+    return this.mediaRepository.find({
+      where: {
+        serviceProfile: { id: profileId },
+        type,
+      },
+      relations: ['serviceProfile'],
     });
   }
 

--- a/back/src/media/media.service.ts
+++ b/back/src/media/media.service.ts
@@ -9,6 +9,7 @@ import { User } from 'src/entities/user.entity';
 import { Repository } from 'typeorm';
 import { ServiceProfile } from 'src/entities/serviceProfile.entity';
 import { Media } from 'src/entities/media.entity';
+import { MediaType } from 'src/enums/mediaType.enum';
 
 @Injectable()
 export class MediaService {
@@ -22,7 +23,40 @@ export class MediaService {
     private readonly mediaEntity: Repository<Media>,
   ) {}
 
-  async uploadMediaService(id: string, file: Express.Multer.File) {
+  // // OBTIENE TODOS LOS DOCUMENTOS EN MEDIA
+  async getAllMediaService() {
+    return this.mediaRepository.getAllMediaRepository();
+  }
+
+  // OBTIENE TODOS LOS DOCUMENTOS EN MEDIA POR TIPO DE UN PERFIL
+  async getMediaByProfileAndTypeService(profileId: string, type: MediaType) {
+    return this.mediaRepository.getMediaByProfileAndTypeRepository(
+      profileId,
+      type,
+    );
+  }
+
+  // CARGA DE FOTO DE PERFIL
+  async uploadProfilePicture(id: string, file: Express.Multer.File) {
+    const profile = await this.serviceProfile.findOneBy({ id });
+    if (!profile) throw new NotFoundException('Perfil no encontrado');
+
+    const uploaded = await this.mediaRepository.uploadImage(file); // Cloudinary, etc.
+    profile.profilePicture = uploaded.secure_url;
+
+    await this.serviceProfile.save(profile);
+    return {
+      message: 'Foto de perfil actualizada',
+      profilePicture: profile.profilePicture,
+    };
+  }
+
+  // CARGA DE FOTOS O DOCUMENTOS
+  async uploadMediaService(
+    id: string,
+    file: Express.Multer.File,
+    type: MediaType = MediaType.GALLERY,
+  ) {
     const profile = await this.serviceProfile.findOne({ where: { id: id } });
     if (!profile)
       throw new NotFoundException(`Proveedor con Id ${id} no encontrado`);
@@ -30,36 +64,37 @@ export class MediaService {
     const media = this.mediaEntity.create({
       imgUrl: uploadedFile.secure_url,
       serviceProfile: profile,
+      type,
     });
 
     await this.mediaEntity.save(media);
     return media;
   }
 
-  async updateUserProfileService(id: string, file: Express.Multer.File) {
-    const user = await this.usersRepository.findOne({ where: { id: id } });
-    if (!user)
-      throw new NotFoundException(`Usuario con Id ${id} no encontrado`);
-    const uploadImage = await this.mediaRepository.uploadImage(file);
-    await this.usersRepository.update(id, { imgUrl: uploadImage.secure_url });
-    const updatedUser = await this.usersRepository.findOneBy({ id: id });
-    return updatedUser;
-  }
+  // async updateUserProfileService(id: string, file: Express.Multer.File) {
+  //   const user = await this.usersRepository.findOne({ where: { id: id } });
+  //   if (!user)
+  //     throw new NotFoundException(`Usuario con Id ${id} no encontrado`);
+  //   const uploadImage = await this.mediaRepository.uploadImage(file);
+  //   await this.usersRepository.update(id, { imgUrl: uploadImage.secure_url });
+  //   const updatedUser = await this.usersRepository.findOneBy({ id: id });
+  //   return updatedUser;
+  // }
 
-  async deleteUserPofileService(id: string) {
-    const user = await this.usersRepository.findOne({ where: { id: id } });
-    if (!user)
-      throw new NotFoundException(`Usuario con Id ${id} no encontrado`);
-    if (!user.imgUrl)
-      throw new BadRequestException(
-        `El usuario no tiene imagen de perfil para eliminar`,
-      );
-    const urlParts = user.imgUrl.split('/');
-    const fileName = urlParts[urlParts.length - 1];
-    const publicId = `avatars/${fileName.split('.')[0]}`;
+  // async deleteUserPofileService(id: string) {
+  //   const user = await this.usersRepository.findOne({ where: { id: id } });
+  //   if (!user)
+  //     throw new NotFoundException(`Usuario con Id ${id} no encontrado`);
+  //   if (!user.imgUrl)
+  //     throw new BadRequestException(
+  //       `El usuario no tiene imagen de perfil para eliminar`,
+  //     );
+  //   const urlParts = user.imgUrl.split('/');
+  //   const fileName = urlParts[urlParts.length - 1];
+  //   const publicId = `avatars/${fileName.split('.')[0]}`;
 
-    await this.mediaRepository.deleteImageRepository(publicId);
-    await this.usersRepository.update(id, { imgUrl: null });
-    return { message: 'Imagen de perfil eliminada exitosamente' };
-  }
+  //   await this.mediaRepository.deleteImageRepository(publicId);
+  //   await this.usersRepository.update(id, { imgUrl: null });
+  //   return { message: 'Imagen de perfil eliminada exitosamente' };
+  // }
 }

--- a/back/src/reviews/reviews.module.ts
+++ b/back/src/reviews/reviews.module.ts
@@ -11,7 +11,10 @@ import { ServiceProfile } from 'src/entities/serviceProfile.entity';
 import { MailModule } from 'src/mail/mail.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Review, Appointment, ServiceProfile]), MailModule],
+  imports: [
+    TypeOrmModule.forFeature([Review, Appointment, ServiceProfile]),
+    MailModule,
+  ],
   controllers: [ReviewsController],
   providers: [
     ReviewsService,

--- a/back/src/reviews/reviews.service.ts
+++ b/back/src/reviews/reviews.service.ts
@@ -20,7 +20,7 @@ export class ReviewsService {
     private readonly reviewsRepository: ReviewsRepository,
     private readonly appointmentRepository: AppointmentsRepository,
     private readonly serviceProfileRepository: ServiceProfileRepository,
-    private readonly mailService: MailService
+    private readonly mailService: MailService,
   ) {}
 
   async createAReviewService(
@@ -133,19 +133,19 @@ export class ReviewsService {
     const softDeletedReview: Review =
       await this.reviewsRepository.createAReviewRepository(entity);
 
-      try {
-        await this.mailService.sendReviewDeletedEmail(
-          entity.user.email,
-          entity.user.name,
-          entity.serviceProfile.serviceTitle,
-          entity.rating,
-          entity.comment,
-          entity.createdAt
-        );
-      } catch (error) {
-        console.error('Error al enviar correo de notificación:', error);
-        // Puedes decidir si quieres lanzar el error o continuar
-      }
+    try {
+      await this.mailService.sendReviewDeletedEmail(
+        entity.user.email,
+        entity.user.name,
+        entity.serviceProfile.serviceTitle,
+        entity.rating,
+        entity.comment,
+        entity.createdAt,
+      );
+    } catch (error) {
+      console.error('Error al enviar correo de notificación:', error);
+      // Puedes decidir si quieres lanzar el error o continuar
+    }
 
     return {
       message: `Review con ${id} eliminado lógicamente`,

--- a/back/src/service-profile/service-profile.controller.ts
+++ b/back/src/service-profile/service-profile.controller.ts
@@ -38,6 +38,16 @@ export class ServiceProfileController {
     return this.serviceProfileService.getAllServiceProfileService();
   }
 
+  // OBTENER PERFILES ACTIVOS (solo admin)
+  @Get('active')
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @UseInterceptors(ExcludeFieldsInterceptor(['password', 'role']))
+  getActivegServiceProfilesController(): Promise<ServiceProfile[]> {
+    return this.serviceProfileService.getActiveServiceProfilesService();
+  }
+
   // OBTENER PERFILES PENDIENTES (solo admin)
   @Get('pending')
   @ApiBearerAuth()
@@ -83,7 +93,7 @@ export class ServiceProfileController {
     );
   }
 
-  // MODIFICAR EL ESTADO DE UN PERFIL POR ID A ACTIVO
+  // MODIFICAR EL ESTADO DE UN PERFIL POR ID A ACTIVO (PENDIENTE O RECHAZADO)
   @Patch('status-active/:id')
   @ApiBearerAuth()
   @UseGuards(AuthGuard, RolesGuard)

--- a/back/src/service-profile/service-profile.repository.ts
+++ b/back/src/service-profile/service-profile.repository.ts
@@ -13,7 +13,23 @@ export class ServiceProfileRepository {
 
   // OBTENER TODOS LOS PERFILES EXISTENTES
   async getAllServiceProfileRepository(): Promise<ServiceProfile[]> {
-    return await this.serviceProfileRepository.find();
+    return await this.serviceProfileRepository.find({
+      where: {
+        deletedAt: null,
+      },
+    });
+  }
+
+  // OBTENER PERFILES ACTIVOS (solo admin)
+  async getActiveServiceProfilesRepository(): Promise<ServiceProfile[]> {
+    return this.serviceProfileRepository
+      .createQueryBuilder('serviceProfile')
+      .leftJoinAndSelect('serviceProfile.user', 'user')
+      .leftJoinAndSelect('serviceProfile.category', 'category')
+      .where('serviceProfile.status = :status', { status: 'active' })
+      .andWhere('serviceProfile.deletedAt IS NULL')
+      .orderBy('serviceProfile.createdAt', 'ASC') // ordena del más viejo al más nuevo ('DESC' para orden inverso)
+      .getMany();
   }
 
   // OBTENER PERFILES PENDIENTES (solo admin)

--- a/back/src/service-profile/service-profile.service.ts
+++ b/back/src/service-profile/service-profile.service.ts
@@ -34,6 +34,11 @@ export class ServiceProfileService {
     return await this.serviceProfileRepository.getAllServiceProfileRepository();
   }
 
+  // OBTENER PERFILES ACTIVOS (solo admin)
+  async getActiveServiceProfilesService(): Promise<ServiceProfile[]> {
+    return await this.serviceProfileRepository.getActiveServiceProfilesRepository();
+  }
+
   // OBTENER PERFILES PENDIENTES (solo admin)
   async getPendingServiceProfilesService(): Promise<ServiceProfile[]> {
     return await this.serviceProfileRepository.getPendingServiceProfilesRepository();
@@ -80,6 +85,12 @@ export class ServiceProfileService {
     serviceProfileData: CreateServiceProfileDto,
     userOfToken: IJwtPayload,
   ): Promise<ServiceProfile> {
+    if (!serviceProfileData.profilePicture) {
+      throw new BadRequestException(
+        'Una foto de perfil es requeridad para ser proveedor de servicios.',
+      );
+    }
+
     const existingProfile =
       await this.serviceProfileRepository.getServiceProfileByUserIdRepository(
         userOfToken.id,
@@ -155,7 +166,7 @@ export class ServiceProfileService {
     return savedServiceProfile;
   }
 
-  // MODIFICAR EL ESTADO DE UN PERFIL POR ID A ACTIVO
+  // MODIFICAR EL ESTADO DE UN PERFIL POR ID A ACTIVO (PENDIENTE O RECHAZADO)
   async updateServiceProfileStatusActiveService(id: string) {
     const serviceProfile: ServiceProfile =
       await this.serviceProfileRepository.getServiceProfileByIdRepository(id);
@@ -166,10 +177,10 @@ export class ServiceProfileService {
       );
     }
 
-    // Validamos que el status actual es "pendiente" antes de actualizarlo
-    if (serviceProfile.status !== ServiceProfileStatus.PENDING) {
+    // Validamos que el status actual no es "active" antes de actualizarlo
+    if (serviceProfile.status === ServiceProfileStatus.ACTIVE) {
       throw new BadRequestException(
-        'Solo perfiles pendientes pueden ser activados',
+        'Solo perfiles pendientes o rechazados pueden ser activados',
       );
     }
 

--- a/back/src/users/users.service.ts
+++ b/back/src/users/users.service.ts
@@ -21,7 +21,7 @@ import { MailService } from 'src/mail/mail.service';
 export class UsersService {
   constructor(
     private readonly usersRepository: UsersRepository,
-    private readonly mailService: MailService
+    private readonly mailService: MailService,
   ) {}
 
   // Get ALL Type of Users
@@ -226,16 +226,16 @@ export class UsersService {
     const softDeletedUser: User =
       await this.usersRepository.saveAUserRepository(entity);
 
-      // Enviar notificación por correo
-  try {
-    await this.mailService.sendAccountDeactivatedEmail(
-      entity.email,
-      entity.name,
-    );
-  } catch (error) {
-    console.error('Error al enviar correo de desactivación:', error);
-    // No lanzamos error para no interrumpir el flujo principal
-  }
+    // Enviar notificación por correo
+    try {
+      await this.mailService.sendAccountDeactivatedEmail(
+        entity.email,
+        entity.name,
+      );
+    } catch (error) {
+      console.error('Error al enviar correo de desactivación:', error);
+      // No lanzamos error para no interrumpir el flujo principal
+    }
 
     return {
       message: `Usuario con ${id} eliminado lógicamente`,


### PR DESCRIPTION
-	Se estableció una ruta para serviceProfile en el que se traiga todos los perfiles activos, así como la de pendig pero para activos. – filtrar solo por status
-	ServiceProfile ahora será solo para administrador
-	Se verificó si cuando traes los serviceProfile te trae solo los activos
-	La foto de perfil debe estar en service profile y no en user (Se cambió ambas entidades y poner la foto de perfil del lado del perfil)
-	Se checó la lógica de service profile para ver si se está aplicando correctamente el tema de la foto de perfil (Es obligatorio)
-	Se agregó a la entidad de service profile para que reciba un array de 2 para la identificación (tanto imágenes como documento) y otro que será opcional pero array abierto para certificados (tanto imágenes como documento)
-     Se crearon los endpoint para la foto de perfil del servicio, para cargar los documentos y certificados y para traer los diferentes tipos de media
-      Se creó un enum para el tipo de media
-	Se checó como se maneja si con media o de otra forma el tema de la subida de los documentos.
-	Se creó endpoint para activar los perfiles de servicio rechazados
